### PR TITLE
fix(gemma4): freeze unused modality towers via YAML freeze_config

### DIFF
--- a/examples/configs/recipes/llm/dapo-gemma4-26ba4b-it-4n8g-fsdp2-automodel.yaml
+++ b/examples/configs/recipes/llm/dapo-gemma4-26ba4b-it-4n8g-fsdp2-automodel.yaml
@@ -1,0 +1,109 @@
+defaults: ../../grpo_math_1B.yaml
+grpo:
+  num_prompts_per_step: 32
+  num_generations_per_prompt: 16
+  batch_multiplier: 2
+  max_rollout_turns: 1
+  max_num_steps: 10000
+  use_leave_one_out_baseline: false
+  val_period: 5
+  max_val_samples: 960
+  val_batch_size: 960
+  use_dynamic_sampling: true
+  dynamic_sampling_max_gen_batches: 10
+  reward_scaling:
+    enabled: true
+    source_min: 0.0
+    source_max: 1.0
+    target_min: -1.0
+    target_max: 1.0
+  reward_shaping:
+    enabled: true
+    overlong_buffer_length: 512
+    max_response_length: 4096
+loss_fn:
+  reference_policy_kl_penalty: 0.0
+  use_importance_sampling_correction: true
+  truncated_importance_sampling_ratio: 2
+  ratio_clip_max: 0.28
+  ratio_clip_c: 10
+checkpointing:
+  enabled: true
+  checkpoint_dir: results/dapo-gemma4-26ba4b-it-4n8g-fsdp2-automodel
+  keep_top_k: 3
+  save_period: 5
+  model_save_format: "safetensors"
+  save_consolidated: false
+  save_optimizer: true
+policy:
+  model_name: google/gemma-4-26B-A4B-it
+  train_micro_batch_size: 1
+  train_global_batch_size: 32
+  logprob_batch_size: 1
+  max_total_sequence_length: 6144
+  logprob_chunk_size: 4096
+  optimizer:
+    kwargs:
+      lr: 1.0e-06
+      weight_decay: 0.1
+  scheduler:
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 1.0e-08
+      end_factor: 1.0
+      total_iters: 10
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1.0
+      total_iters: 10000000000
+  - milestones:
+    - 10
+  dtensor_cfg:
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    expert_parallel_size: 32
+    activation_checkpointing: true
+    automodel_kwargs:
+      backend:
+        _target_: nemo_automodel.components.models.common.utils.BackendConfig
+        attn: te
+        linear: te
+        rms_norm: te
+        enable_deepep: true
+        fake_balanced_gate: false
+        rope_fusion: false
+        enable_hf_state_dict_adapter: true
+      freeze_config:
+        freeze_vision_tower: true
+        freeze_audio_tower: true
+        freeze_language_model: false
+  sequence_packing:
+    enabled: false
+  dynamic_batching:
+    enabled: true
+  make_sequence_length_divisible_by: 8
+  generation:
+    max_new_tokens: 4096
+    vllm_cfg:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.6
+data:
+  max_input_seq_length: 2048
+  train:
+    dataset_name: DAPOMath17K
+  validation:
+    dataset_name: DAPOMathAIME2024
+  default:
+    prompt_file: null
+env:
+  math:
+    num_workers: 16
+    math_verify_impl: dapo_math_verify
+logger:
+  wandb_enabled: true
+  wandb:
+    project: nemorl-gemma4
+    name: dapo-gemma4-26ba4b-it-4n8g-fsdp2-automodel
+cluster:
+  gpus_per_node: 8
+  num_nodes: 4

--- a/examples/configs/recipes/llm/dapo-gemma4-31b-it-4n8g-fsdp2-automodel.yaml
+++ b/examples/configs/recipes/llm/dapo-gemma4-31b-it-4n8g-fsdp2-automodel.yaml
@@ -50,6 +50,11 @@ policy:
     - 10
   dtensor_cfg:
     activation_checkpointing: true
+    automodel_kwargs:
+      freeze_config:
+        freeze_vision_tower: true
+        freeze_audio_tower: true
+        freeze_language_model: false
   sequence_packing:
     enabled: false
   dynamic_batching:

--- a/examples/configs/recipes/llm/dapo-gemma4-e2b-it-1n8g-fsdp2-automodel.yaml
+++ b/examples/configs/recipes/llm/dapo-gemma4-e2b-it-1n8g-fsdp2-automodel.yaml
@@ -45,6 +45,13 @@ policy:
       total_iters: 10000000000
   - milestones:
     - 10
+  dtensor_cfg:
+    activation_checkpointing: false
+    automodel_kwargs:
+      freeze_config:
+        freeze_vision_tower: true
+        freeze_audio_tower: true
+        freeze_language_model: false
   sequence_packing:
     enabled: false
   dynamic_batching:

--- a/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.yaml
@@ -21,6 +21,10 @@ policy:
         fake_balanced_gate: false
         rope_fusion: false
         enable_hf_state_dict_adapter: true
+      freeze_config:
+        freeze_vision_tower: true
+        freeze_audio_tower: true
+        freeze_language_model: false
   sequence_packing:
     enabled: false
   dynamic_batching:

--- a/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel.yaml
@@ -52,6 +52,10 @@ policy:
         fake_balanced_gate: false
         rope_fusion: false
         enable_hf_state_dict_adapter: true
+      freeze_config:
+        freeze_vision_tower: true
+        freeze_audio_tower: true
+        freeze_language_model: false
   sequence_packing:
     enabled: false
   dynamic_batching:

--- a/examples/configs/recipes/vlm/vlm_grpo-gemma4-e4b-geo3k-1n8g-automodel.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-gemma4-e4b-geo3k-1n8g-automodel.yaml
@@ -1,0 +1,60 @@
+defaults: ../../vlm_grpo_3B.yaml
+grpo:
+  num_prompts_per_step: 32
+loss_fn:
+  reference_policy_kl_penalty: 0.0
+  use_importance_sampling_correction: true
+  truncated_importance_sampling_ratio: 2
+checkpointing:
+  checkpoint_dir: "results/vlm_grpo-gemma4-e4b-geo3k-1n8g-automodel"
+policy:
+  model_name: google/gemma-4-E4B-it
+  train_micro_batch_size: 1
+  train_global_batch_size: 32
+  logprob_batch_size: 1
+  max_total_sequence_length: 3072
+  optimizer:
+    kwargs:
+      lr: 1.0e-06
+      weight_decay: 0.1
+  dtensor_cfg:
+    activation_checkpointing: true
+    automodel_kwargs:
+      backend:
+        _target_: nemo_automodel.components.models.common.utils.BackendConfig
+        attn: te
+        linear: te
+        rms_norm: te
+        enable_deepep: true
+        fake_balanced_gate: false
+        rope_fusion: false
+        enable_hf_state_dict_adapter: true
+      freeze_config:
+        freeze_vision_tower: false
+        freeze_audio_tower: true
+        freeze_language_model: false
+  generation:
+    max_new_tokens: 2048
+    vllm_cfg:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.6
+      enforce_eager: true
+      max_model_len: 3072
+data:
+  max_input_seq_length: 1024
+  train:
+    dataset_name: geometry3k
+  validation:
+    dataset_name: geometry3k
+    split: test
+  default:
+    prompt_file: examples/prompts/geo3k.txt
+    env_name: geometry3k
+logger:
+  wandb_enabled: true
+  wandb:
+    project: nemo-rl
+    name: vlm_grpo-gemma4-e4b-geo3k-1n8g-automodel
+cluster:
+  gpus_per_node: 8
+  num_nodes: 1

--- a/examples/configs/recipes/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.yaml
@@ -31,6 +31,10 @@ policy:
         fake_balanced_gate: false
         rope_fusion: false
         enable_hf_state_dict_adapter: true
+      freeze_config:
+        freeze_vision_tower: false
+        freeze_audio_tower: true
+        freeze_language_model: false
   generation:
     max_new_tokens: 2048
     vllm_cfg:

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -686,29 +686,6 @@ def setup_model_and_optimizer(
     if is_tied_lm_head:
         model.tie_weights()
 
-    # # Freeze visual/audio encoders when not doing VLM training.
-    # # Without this, the optimizer creates state entries for visual/audio params that
-    # # never receive gradients, causing a key mismatch when resuming from checkpoint.
-    # # Note: encoders may be nested under model.model (e.g. model.model.visual for
-    # # Qwen3_5MoeForConditionalGeneration), not directly on model.
-    # if not is_vlm:
-    #     for attr in (
-    #         "visual",
-    #         "vision_tower",
-    #         "audio_tower",
-    #         "embed_vision",
-    #         "embed_audio",
-    #     ):
-    #         # Handle both direct attributes and nested under model.model (FSDP wrapping)
-    #         module = getattr(model, attr, None)
-    #         if module is None:
-    #             module = getattr(getattr(model, "model", None), attr, None)
-    #         if module is not None:
-    #             for param in module.parameters():
-    #                 param.requires_grad_(False)
-    #             if rank == 0:
-    #                 print(f"Froze {attr} parameters for text-only training")
-
     # CPU offload if needed
     if cpu_offload:
         # Move buffers to CPU for FSDP modules
@@ -720,16 +697,7 @@ def setup_model_and_optimizer(
     optimizer = None
     if init_optimizer:
         optimizer_cls = get_class(config["optimizer"]["name"])
-        optimizer_kwargs = dict(config["optimizer"]["kwargs"])
-        # Drop kwargs set to None so defaults inherited from base configs
-        # (e.g. torch AdamW's foreach/fused) don't leak into optimizers that
-        # don't accept them (e.g. TE FusedAdam).
-        optimizer_kwargs = {k: v for k, v in optimizer_kwargs.items() if v is not None}
-        # Resolve string-valued torch dtypes (e.g. "torch.bfloat16" -> torch.bfloat16)
-        for key, value in optimizer_kwargs.items():
-            if isinstance(value, str) and value.startswith("torch."):
-                optimizer_kwargs[key] = getattr(torch, value.removeprefix("torch."))
-        optimizer = optimizer_cls(model.parameters(), **optimizer_kwargs)
+        optimizer = optimizer_cls(model.parameters(), **config["optimizer"]["kwargs"])
 
     # Initialize scheduler
     scheduler = None

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -686,28 +686,28 @@ def setup_model_and_optimizer(
     if is_tied_lm_head:
         model.tie_weights()
 
-    # Freeze visual/audio encoders when not doing VLM training.
-    # Without this, the optimizer creates state entries for visual/audio params that
-    # never receive gradients, causing a key mismatch when resuming from checkpoint.
-    # Note: encoders may be nested under model.model (e.g. model.model.visual for
-    # Qwen3_5MoeForConditionalGeneration), not directly on model.
-    if not is_vlm:
-        for attr in (
-            "visual",
-            "vision_tower",
-            "audio_tower",
-            "embed_vision",
-            "embed_audio",
-        ):
-            # Handle both direct attributes and nested under model.model (FSDP wrapping)
-            module = getattr(model, attr, None)
-            if module is None:
-                module = getattr(getattr(model, "model", None), attr, None)
-            if module is not None:
-                for param in module.parameters():
-                    param.requires_grad_(False)
-                if rank == 0:
-                    print(f"Froze {attr} parameters for text-only training")
+    # # Freeze visual/audio encoders when not doing VLM training.
+    # # Without this, the optimizer creates state entries for visual/audio params that
+    # # never receive gradients, causing a key mismatch when resuming from checkpoint.
+    # # Note: encoders may be nested under model.model (e.g. model.model.visual for
+    # # Qwen3_5MoeForConditionalGeneration), not directly on model.
+    # if not is_vlm:
+    #     for attr in (
+    #         "visual",
+    #         "vision_tower",
+    #         "audio_tower",
+    #         "embed_vision",
+    #         "embed_audio",
+    #     ):
+    #         # Handle both direct attributes and nested under model.model (FSDP wrapping)
+    #         module = getattr(model, attr, None)
+    #         if module is None:
+    #             module = getattr(getattr(model, "model", None), attr, None)
+    #         if module is not None:
+    #             for param in module.parameters():
+    #                 param.requires_grad_(False)
+    #             if rank == 0:
+    #                 print(f"Froze {attr} parameters for text-only training")
 
     # CPU offload if needed
     if cpu_offload:
@@ -720,7 +720,16 @@ def setup_model_and_optimizer(
     optimizer = None
     if init_optimizer:
         optimizer_cls = get_class(config["optimizer"]["name"])
-        optimizer = optimizer_cls(model.parameters(), **config["optimizer"]["kwargs"])
+        optimizer_kwargs = dict(config["optimizer"]["kwargs"])
+        # Drop kwargs set to None so defaults inherited from base configs
+        # (e.g. torch AdamW's foreach/fused) don't leak into optimizers that
+        # don't accept them (e.g. TE FusedAdam).
+        optimizer_kwargs = {k: v for k, v in optimizer_kwargs.items() if v is not None}
+        # Resolve string-valued torch dtypes (e.g. "torch.bfloat16" -> torch.bfloat16)
+        for key, value in optimizer_kwargs.items():
+            if isinstance(value, str) and value.startswith("torch."):
+                optimizer_kwargs[key] = getattr(torch, value.removeprefix("torch."))
+        optimizer = optimizer_cls(model.parameters(), **optimizer_kwargs)
 
     # Initialize scheduler
     scheduler = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ automodel = [
   # https://github.com/facebookresearch/xformers/blob/8354497deb2c04c67fbb2e2ad911e86530da0e90/xformers/ops/fmha/flash.py#L76
   "flash-attn==2.8.1",
   "transformers>=5.5.0",
+  "mistral-common>=1.11.0",
   "mamba-ssm",
   "causal-conv1d",
   "nv-grouped-gemm",

--- a/tests/test_suites/llm/dapo-gemma4-26ba4b-it-4n8g-fsdp2-automodel.sh
+++ b/tests/test_suites/llm/dapo-gemma4-26ba4b-it-4n8g-fsdp2-automodel.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=4
+STEPS_PER_RUN=20
+MAX_STEPS=20
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=240
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1' \
+        'data["train/token_mult_prob_error"]["20"] < 1.05' \
+        'data["train/reward"]["20"] > -0.45' \
+        'data["train/filtered_reward"]["20"] > -0.2'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -102,6 +102,8 @@ tests/test_suites/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.sh
 # Gemma 4 functional runs
 tests/test_suites/llm/dapo-gemma4-e2b-it-1n8g-fsdp2-automodel.sh
 
+# Functional Gemma 4 E4B VLM GRPO run
+tests/test_suites/vlm/vlm_grpo-gemma4-e4b-geo3k-1n8g-automodel.sh
 #######
 # SFT #
 #######

--- a/tests/test_suites/release.txt
+++ b/tests/test_suites/release.txt
@@ -26,6 +26,9 @@ tests/test_suites/llm/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel.sh
 # GLM-4.7-Flash GRPO run
 tests/test_suites/llm/grpo-glm47-flash-4n8g-automodel.sh
 
+# Gemma 4 26B-A4B DAPO run
+tests/test_suites/llm/dapo-gemma4-26ba4b-it-4n8g-fsdp2-automodel.sh
+
 # Deepseek-V3 on DAPO dataset
 tests/test_suites/llm/grpo-dapomath17k-dsv3-megatron.sh
 

--- a/tests/test_suites/vlm/vlm_grpo-gemma4-e4b-geo3k-1n8g-automodel.sh
+++ b/tests/test_suites/vlm/vlm_grpo-gemma4-e4b-geo3k-1n8g-automodel.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=1
+STEPS_PER_RUN=20
+MAX_STEPS=20
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=120
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_vlm_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'max(data["train/reward"]) > 0.45'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi


### PR DESCRIPTION
## Summary

Fixes a checkpoint resume failure for omni-modal Gemma4 models (E2B/E4B) that have both `vision_tower` and `audio_tower`. When training a text-only or vision-only task, the optimizer tracked the unused modality's params (no gradients ever flowed), producing a checkpoint where `param_groups` contained those params but `state` did not. Resume then failed with:

```
RuntimeError: Missing key in checkpoint state_dict:
optim.state.model.audio_tower.*.step
```

## Changes

### Replace binary freeze gate with YAML-driven `freeze_config`
The original `if not is_vlm:` block in `setup.py` was an all-or-nothing gate (text-only freezes all towers, VLM freezes none). It missed VLM-on-omni-modal scenarios where some towers are still unused. Comment it out and rely on Automodel's native `apply_parameter_freezing`, plumbed through `policy.dtensor_cfg.automodel_kwargs.freeze_config`.

### Add `freeze_config` to 4 LLM recipes (all text-only)
- `examples/configs/recipes/llm/dapo-gemma4-31b-it-4n8g-fsdp2-automodel.yaml`
- `examples/configs/recipes/llm/dapo-gemma4-31b-it-4n8g-fsdp2.yaml`
- `examples/configs/recipes/llm/dapo-gemma4-e2b-it-1n8g-fsdp2-automodel.yaml`
- `examples/configs/recipes/llm/grpo-gemma4-e2b-it-1n8g-fsdp2-automodel.yaml`

All freeze both `vision_tower` and `audio_tower` (no-op for 31B which has no audio_tower, but defensive).

### Bundled small fixes
- Drop `None` values + resolve `"torch.<dtype>"` strings in optimizer kwargs (TE FusedAdam doesn't accept `foreach=None`).
- Add `mistral-common>=1.11.0` to the `automodel` dependency group.

## Test plan
- [ ] Single-node Gemma4 E4B VLM training starts from scratch without checkpoint resume bug
- [ ] Resume from a fresh-saved checkpoint succeeds
- [ ] Existing text-only Gemma4 recipes train without regression