### PR TITLE
fix: pass VLLM serving kwargs through OpenAIServingRender

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -462,14 +462,24 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
 
                 return res
 
+        http_server_kwargs = self.cfg["vllm_cfg"].get(
+            "http_server_serving_chat_kwargs", {}
+        )
         openai_serving_render = NeMoRLOpenAIServingRender(
             model_config=model_config,
             renderer=engine_client.renderer,
             io_processor=engine_client.io_processor,
             model_registry=openai_serving_models.registry,
             request_logger=None,
-            chat_template=None,
-            chat_template_content_format="auto",
+            chat_template=http_server_kwargs.get("chat_template", None),
+            chat_template_content_format=http_server_kwargs.get("chat_template_content_format", "auto"),
+            trust_request_chat_template=http_server_kwargs.get("trust_request_chat_template", False),
+            enable_auto_tools=http_server_kwargs.get("enable_auto_tools", False),
+            exclude_tools_when_tool_choice_none=http_server_kwargs.get("exclude_tools_when_tool_choice_none", False),
+            tool_parser=http_server_kwargs.get("tool_parser", None),
+            reasoning_parser=http_server_kwargs.get("reasoning_parser", None),
+            default_chat_template_kwargs=http_server_kwargs.get("default_chat_template_kwargs", None),
+            log_error_stack=http_server_kwargs.get("log_error_stack", False),
         )
 
         ########################################


### PR DESCRIPTION
# What does this PR do ?

Passes `vllm_cfg.http_server_serving_chat_kwargs` through `NeMoRLOpenAIServingRender` to enable tool parsing and chat template overrides on the VLLM server side.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
