### PR TITLE
fix: remove reasoning_parser from OpenAIServingRender args

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -477,7 +477,6 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
             enable_auto_tools=http_server_kwargs.get("enable_auto_tools", False),
             exclude_tools_when_tool_choice_none=http_server_kwargs.get("exclude_tools_when_tool_choice_none", False),
             tool_parser=http_server_kwargs.get("tool_parser", None),
-            reasoning_parser=http_server_kwargs.get("reasoning_parser", None),
             default_chat_template_kwargs=http_server_kwargs.get("default_chat_template_kwargs", None),
             log_error_stack=http_server_kwargs.get("log_error_stack", False),
         )


### PR DESCRIPTION
# What does this PR do ?

Removes `reasoning_parser` from `NeMoRLOpenAIServingRender` construction since it is introduced in a later VLLM version (0.19 vs 0.20)

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
* 

VLLM v0.19.0:
```python
class OpenAIServingRender:
    def __init__(
        self,
        model_config: ModelConfig,
        renderer: BaseRenderer,
        io_processor: Any,
        model_registry: OpenAIModelRegistry,
        *,
        request_logger: RequestLogger | None,
        chat_template: str | None,
        chat_template_content_format: ChatTemplateContentFormatOption,
        trust_request_chat_template: bool = False,
        enable_auto_tools: bool = False,
        exclude_tools_when_tool_choice_none: bool = False,
        tool_parser: str | None = None,
        default_chat_template_kwargs: dict[str, Any] | None = None,
        log_error_stack: bool = False,
```


VLLM v0.20.0:
```python
class OpenAIServingRender:
    def __init__(
        self,
        model_config: ModelConfig,
        renderer: BaseRenderer,
        model_registry: OpenAIModelRegistry,
        *,
        request_logger: RequestLogger | None,
        chat_template: str | None,
        chat_template_content_format: ChatTemplateContentFormatOption,
        trust_request_chat_template: bool = False,
        enable_auto_tools: bool = False,
        exclude_tools_when_tool_choice_none: bool = False,
        tool_parser: str | None = None,
        reasoning_parser: str | None = None,
        default_chat_template_kwargs: dict[str, Any] | None = None,
        log_error_stack: bool = False,
```